### PR TITLE
Create default configuration for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableDependencyDashboard"],
-
-  "semanticCommits": "disabled",
-
-  "pre-commit": {
-    "enabled": true
-  }
+  "extends": ["local>otterbuild/renovate-config"]
 }

--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,18 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:base"],
+
+  // Automatically merge PRs if the required status checks on GitHub pass
+  automerge: true,
+
+  // Do not use a GitHub issue to track dependency updates
+  dependencyDashboard: false,
+
+  // Do not prefix commit messages with the semantic commit type
+  semanticCommits: "disabled",
+
+  // Keep pre-commit hooks up-to-date
+  "pre-commit": {
+    enabled: true,
+  },
+}


### PR DESCRIPTION
The existing configuration for Renovate has been moved to a sharable preset. This preset will be used by all repositories in the Otterbuild organization.