### PR TITLE
Assign unmergeable pull requests

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
 
+  "assignees": ["jdno"],
+  "reviewers": ["jdno"],
+
   "automerge": true,
   "dependencyDashboard": false,
   "semanticCommits": "disabled",


### PR DESCRIPTION
Renovate has been configured and approved to automatically merge pull requests that pass the required status checks. To catch pull requests that fail the checks and cannot be merged, we are assigning them to @jdno.