### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -34,7 +34,7 @@ jobs:
           done
 
   style:
-    name: Check style
+    name: Check JSON style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -34,7 +34,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint Markdown files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -50,7 +50,7 @@ jobs:
           files: "**.md"
 
   style:
-    name: Check style
+    name: Check Markdown style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -35,7 +35,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint YAML files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -49,7 +49,7 @@ jobs:
         uses: actionshub/yamllint@v1.8.2
 
   style:
-    name: Check style
+    name: Check YAML style
     runs-on: ubuntu-latest
 
     needs: detect-changes


### PR DESCRIPTION
The workflows have been updated[^1] to have unique names, which is necessary to fix an issue with Renovate auto-merging breaking pull requests.

[^1]: https://github.com/otterbuild/workflows/pull/43