### PR TITLE
Update Rust toolchain

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,5 +10,26 @@
   "semanticCommits": "disabled",
   "pre-commit": {
     "enabled": true
-  }
+  },
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.github/workflows/[\\w]+.yml$"],
+      "matchStrings": ["prefix-key: [\\w]+-(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
+      ],
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-tags"
+    }
+  ]
 }


### PR DESCRIPTION
Custom matchers have been added to the configuration to update the Rust toolchain, both in `rust-toolchain.toml` and in GitHub Actions. For the latter, we tend to version the cache using the Rust version and want to update the cache key as a new Rust version is released.